### PR TITLE
Get binDir correctly on case sensitive file systems (e.g. Linux)

### DIFF
--- a/pyrlottie/__init__.py
+++ b/pyrlottie/__init__.py
@@ -181,7 +181,7 @@ def _getBinDir() -> str:
 	"""
 	system = platform.system()
 	machine = platform.machine()
-	binDir = f"{THISDIR}/{system}_{machine}".lower()
+	binDir = f"{THISDIR}/{system.lower()}_{machine.lower()}"
 	if Path(binDir).exists():
 		return binDir
 	raise OSError(f"Sorry, your environment is not currently supported! {system=} {machine=}")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/FredHappyface/.github/blob/master/CONTRIBUTING.md
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `master` branch.
* Include a description of the proposed changes and how to test them.
-->

### What is the purpose of this pull request? (put an "X" next to item)

- [ ] Documentation update
- [X] Bug fix
- [ ] New feature
- [ ] Other, please explain:

### What changes did you make? (Give an overview)
The function to get bin directory makes the entire path to lowercase, which will be a problem on systems like Linux, where the file system is case sensitive.

For example, `/home/user/Documents/a/b/c` gets converted to `/home/user/documents/a/b/c`. This works on Windows, because for it, files aren't case sensitive, but for linux, `Documents` and `documents` are two separate paths.

I've removed the `.lower()` from the entire path, and have just added it to `machine` and `system`.

```python3
binDir = f"{THISDIR}/{system}_{machine}".lower()
# Using this instead of above one	
binDir = f"{THISDIR}/{system.lower()}_{machine.lower()}"
```

### Which issue (if any) does this pull request address?

None

### Is there anything you'd like reviewers to focus on?

This is a simple bug fix, but without it, pyrlottie would not even run on Linux.